### PR TITLE
FIX LOGIN 1

### DIFF
--- a/web_server.log
+++ b/web_server.log
@@ -1,0 +1,4 @@
+[2025-09-01 02:26:17 +0000] [2107] [INFO] Starting gunicorn 22.0.0
+[2025-09-01 02:26:17 +0000] [2107] [INFO] Listening at: http://127.0.0.1:8000 (2107)
+[2025-09-01 02:26:17 +0000] [2107] [INFO] Using worker: sync
+[2025-09-01 02:26:17 +0000] [2226] [INFO] Booting worker with pid: 2226

--- a/website/web_dashboard.py
+++ b/website/web_dashboard.py
@@ -291,6 +291,8 @@ def index():
 
 @app.route("/login")
 def login():
+    if 'discord_token' in session:
+        return redirect(url_for('dashboard_home'))
     discord = make_user_session()
     authorization_url, state = discord.authorization_url(AUTHORIZATION_BASE_URL)
     session['oauth2_state'] = state


### PR DESCRIPTION
This commit fixes a bug where authenticated users would get stuck in a redirect loop if they navigated to the /login page.

The /login route was unconditionally redirecting to the Discord OAuth2 authorization page, even if the user already had a valid session. This commit adds a check to the /login route to first verify if a 'discord_token' exists in the session. If it does, the user is redirected to the dashboard, avoiding the unnecessary re-authentication and the resulting redirect loop.